### PR TITLE
fix: lack return 

### DIFF
--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -107,6 +107,7 @@ func runHandler(w http.ResponseWriter, r *http.Request) {
 	action, exists := cont.Image.Actions[req.Action]
 	if !exists {
 		sendRunError(w, fmt.Sprintf("action %s not found with template %s", req.Action, req.SandId), nil)
+		return
 	}
 
 	//nolint


### PR DESCRIPTION
If the action does not exist,  should be directly returned without proceeding with the subsequent steps. 